### PR TITLE
Host DApp on IPFS and use the INFURA kovan endpoint

### DIFF
--- a/app/config.json
+++ b/app/config.json
@@ -1,5 +1,5 @@
 {
-    "network": "testnet",
+    "network": "development",
     "testnet": {
         "services": "0x5501FD8B64D4Cf6f532947D6dDf6591542844482",
         "endpoint": "https://kovan.infura.io/metamask"

--- a/app/config.json
+++ b/app/config.json
@@ -1,7 +1,8 @@
 {
     "network": "testnet",
     "testnet": {
-        "services": "0x5501FD8B64D4Cf6f532947D6dDf6591542844482"
+        "services": "0x5501FD8B64D4Cf6f532947D6dDf6591542844482",
+        "endpoint": "https://kovan.infura.io/metamask"
     },
     "development": {
     }

--- a/app/index.html
+++ b/app/index.html
@@ -177,6 +177,7 @@
               <th>Beneficiary</th>
               <th>Pending Cents</th>
               <th>Cents</th>
+              <th>Margin</th>
             </tr>
           </thead>
           <tbody></tbody>

--- a/app/javascripts/app.js
+++ b/app/javascripts/app.js
@@ -19,6 +19,11 @@ const endpoint = getEndpoint(config, truffleJs)
 window.App = {
     start: function() {
         const self = this
+        console.log("netConfig:", netConfig);
+
+        console.log("truffle:", truffleJs);
+
+        console.log("web3 network:", web3.version.network);
 
         let servicesAddr
         if (netConfig && netConfig.services) {
@@ -139,10 +144,11 @@ window.App = {
                         bvc.beneficiary.call(),
                         bvc.pendingNotionalCents.call(),
                         bvc.notionalCents.call(),
+                        bvc.currentMargin.call(),
                         self.contractStore.isOpen.call(addr)
                     ])
                 }).then((bvcValues) => {
-                    const isOpen = (bvcValues[4] === true)
+                    const isOpen = (bvcValues[5] === true)
                     const tbl = (isOpen) ? tOpen : tClosed
                     tbl.append(
                         row([
@@ -151,6 +157,7 @@ window.App = {
                             addrFmt(bvcValues[1]),
                             bvcValues[2],
                             bvcValues[3],
+                            web3.toBigNumber(web3.fromWei(bvcValues[4], 'ether')).plus(1).toString() + "x",
                         ])
                     )
                 })

--- a/app/javascripts/app.js
+++ b/app/javascripts/app.js
@@ -19,11 +19,6 @@ const endpoint = getEndpoint(config, truffleJs)
 window.App = {
     start: function() {
         const self = this
-        console.log("netConfig:", netConfig);
-
-        console.log("truffle:", truffleJs);
-
-        console.log("web3 network:", web3.version.network);
 
         let servicesAddr
         if (netConfig && netConfig.services) {
@@ -395,6 +390,9 @@ window.addEventListener('load', () => {
     web3.eth.getBlockNumber((err, res) => {
         console.log(`block height: ${res}`)
     })
+    console.log("web3 network:", web3.version.network);
+    console.log("truffle:", truffleJs);
+    console.log("netConfig:", netConfig);
 
     displayStatus()
 

--- a/app/javascripts/app.js
+++ b/app/javascripts/app.js
@@ -13,10 +13,8 @@ import exJSON from '../../build/contracts/ExchangeRate.json'
 
 import truffleJs from '../../truffle'
 import config from '../config.json'
-const netConfig = truffleJs.networks[config.network]
-const endpoint = (netConfig)
-    ? `http://${netConfig.host}:${netConfig.port}`
-    : `http://localhost:8545`
+const netConfig = config[config.network]
+const endpoint = getEndpoint(config, truffleJs)
 
 window.App = {
     start: function() {
@@ -307,7 +305,7 @@ function displayStatus() {
     const tbl = $('#status-table tbody')
     const add = (name, addr) => { tbl.append(row([name, addr])) }
     add("web3 connected", web3.isConnected())
-    add("web3 provider", web3.currentProvider.host)
+    add("web3 provider", providerToString(web3.currentProvider))
     web3.version.getNetwork((err, res) => {
         add("network", res)
     })
@@ -345,6 +343,33 @@ function sendToQueue() {
     })
 }
 
+function providerToString(provider) {
+    let pStr
+    if (web3.currentProvider.isMetaMask === true) {
+        pStr = "MetaMask"
+    } else {
+        pStr = web3.currentProvider.host
+    }
+    return pStr
+}
+
+/**
+ * Use app/config.js override if exists, otherwise use the truffle network settings.
+ * This allows an infura.io public endpoint to be used for the DApp but a local
+ * one for migrations.
+ */
+function getEndpoint(config, truffleJs) {
+    let endpoint
+    const appNet = config.network
+    if (config[appNet].endpoint) {
+        endpoint = config[appNet].endpoint
+    } else {
+        const tNet = truffleJs.networks[appNet]
+        endpoint = `http://${tNet.host}:${tNet.port}`
+    }
+    return endpoint
+}
+
 window.addEventListener('load', () => {
     // Checking if Web3 has been injected by the browser
     if (typeof web3 !== 'undefined') {
@@ -359,6 +384,10 @@ window.addEventListener('load', () => {
     window.web3.eth.defaultAccount = web3.eth.accounts[0]
 
     console.log(`isConnected: ${window.web3.isConnected()}`)
+    console.log(`web3 provider: ${providerToString(web3.currentProvider)}`)
+    web3.eth.getBlockNumber((err, res) => {
+        console.log(`block height: ${res}`)
+    })
 
     displayStatus()
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "webpack",
-    "dev": "webpack-dev-server --port 9999",
+    "dev": "webpack-dev-server --port 9999 --host 0.0.0.0",
     "deploy-web": "docker exec -it ipfs-daemon ipfs add -r /stage/build",
     "test": "truffle test"
   },


### PR DESCRIPTION
So with this we don't need to host a parity node or a webserver.
Although we do need to host an ipfs daemon now to ensure the site hash is found. I'm running this on my AWS server for now.

@gnidan i cherry picked your changes to here from the ui-new-features branch as they didn't make it in.